### PR TITLE
Add fallback import for run_dct

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,10 @@ import argparse
 import pandas as pd
 from pprint import pprint
 
-from run_dct import H36MRunner, CMURunner
+try:
+    from run_dct import H36MRunner, CMURunner
+except ImportError:  # fallback for environments without the DCT runners
+    from run import H36MRunner, CMURunner
 from datas_dct import define_actions, define_actions_cmu
 
 parser = argparse.ArgumentParser(description='manual to this script')

--- a/short_term_main.py
+++ b/short_term_main.py
@@ -27,7 +27,10 @@ import argparse
 import pandas as pd
 from pprint import pprint
 
-from run_dct import H36MRunner, CMURunner
+try:
+    from run_dct import H36MRunner, CMURunner
+except ImportError:  # fallback for environments without the DCT runners
+    from run import H36MRunner, CMURunner
 from datas_dct import define_actions, define_actions_cmu
 
 parser = argparse.ArgumentParser(description='manual to this script')


### PR DESCRIPTION
## Summary
- guard against missing `run_dct` module
- add the same fallback to `short_term_main.py`

## Testing
- `python -m py_compile main.py short_term_main.py`

------
https://chatgpt.com/codex/tasks/task_e_685da04cbae08321ac048dccb98e1c0b