### PR TITLE
Refactor loader and add CLI options

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -1,20 +1,24 @@
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 import os
 import getpass
 import torch
 import numpy as np
 
 class Config():
-    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15, device="cuda:0", num_works=0, test_manner="all"):
+    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15,
+                 device="cuda:0", num_works=0, test_manner="all",
+                 train_batch_size=16, lr=2e-4, n_epoch=5000):
         self.platform = getpass.getuser()
         assert exp_name in ["h36m", "cmu", "3dpw"]
         self.exp_name = exp_name
 
         self.p_dropout = 0.1
-        self.train_batch_size = 16
+        self.train_batch_size = train_batch_size
         self.test_batch_size = 128
-        self.lr = 2e-4
+        self.lr = lr
         self.lr_decay = 0.98
-        self.n_epoch = 5000
+        self.n_epoch = n_epoch
         self.leaky_c = 0.2
 
         self.test_manner = test_manner

--- a/datas/__init__.py
+++ b/datas/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/cmu/__init__.py
+++ b/datas/cmu/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/cmu/motiondataset.py
+++ b/datas/cmu/motiondataset.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas/data_utils.py
+++ b/datas/data_utils.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/draw_pictures.py
+++ b/datas/draw_pictures.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/forward_kinematics.py
+++ b/datas/forward_kinematics.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/h36m/__init__.py
+++ b/datas/h36m/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/h36m/motiondataset.py
+++ b/datas/h36m/motiondataset.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas/multi_scale.py
+++ b/datas/multi_scale.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/your_data_loader.py
+++ b/datas/your_data_loader.py
@@ -1,0 +1,34 @@
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+import numpy as np
+
+class DataLoader:
+    def __init__(self, path):
+        self.path = path
+        self.data = None
+
+    def load(self):
+        logging.info("Loading data from %s", self.path)
+        try:
+            self.data = np.loadtxt(self.path, delimiter=',')
+        except Exception as e:
+            logging.error("Failed to load data: %s", e)
+            raise
+        logging.info("Finished loading data")
+        return self.data
+
+    def preprocess(self):
+        logging.info("Preprocessing data")
+        if self.data is None:
+            raise ValueError("No data loaded")
+        self.data = (self.data - np.mean(self.data, axis=0)) / (np.std(self.data, axis=0) + 1e-8)
+        logging.info("Finished preprocessing data")
+        return self.data
+
+    def save(self, out_path):
+        logging.info("Saving data to %s", out_path)
+        if self.data is None:
+            raise ValueError("No data to save")
+        np.savetxt(out_path, self.data, delimiter=',')
+        logging.info("Finished saving data")

--- a/datas_dct/__init__.py
+++ b/datas_dct/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/cmu/__init__.py
+++ b/datas_dct/cmu/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/cmu/motiondataset.py
+++ b/datas_dct/cmu/motiondataset.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas_dct/data_utils.py
+++ b/datas_dct/data_utils.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/dct.py
+++ b/datas_dct/dct.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 import torch

--- a/datas_dct/draw_pictures.py
+++ b/datas_dct/draw_pictures.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/forward_kinematics.py
+++ b/datas_dct/forward_kinematics.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/h36m/__init__.py
+++ b/datas_dct/h36m/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/h36m/motiondataset.py
+++ b/datas_dct/h36m/motiondataset.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas_dct/multi_scale.py
+++ b/datas_dct/multi_scale.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 import numpy as np
 import random
 import torch
@@ -35,6 +37,9 @@ parser.add_argument('--device', type=str, default="cuda:0", help="")
 parser.add_argument('--num_works', type=int, default=0)
 parser.add_argument('--test_manner', type=str, default="all", help="all / 8")
 parser.add_argument('--debug_step', type=int, default=1, help="")
+parser.add_argument('--batch-size', type=int, default=16, help="training batch size")
+parser.add_argument('--epochs', type=int, default=5000, help="number of epochs")
+parser.add_argument('--learning-rate', type=float, default=2e-4, help="initial learning rate")
 parser.add_argument('--is_train', type=bool, default='', help="")
 parser.add_argument('--is_load', type=bool, default='', help="")
 parser.add_argument('--model_path', type=str, default="", help="")
@@ -51,26 +56,34 @@ if args.dct == True:
     if args.exp_name == "h36m":
         r = H36MRunner(exp_name=args.exp_name, input_n=args.input_n, output_n=args.output_n, dct_n=args.dct_n,
                        device=args.device, num_works=args.num_works,
-                       test_manner=args.test_manner, debug_step=args.debug_step)
+                       test_manner=args.test_manner, debug_step=args.debug_step,
+                       batch_size=args.batch_size, epochs=args.epochs,
+                       learning_rate=args.learning_rate)
         acts = define_actions("all")
 
     elif args.exp_name == "cmu":
         r = CMURunner(exp_name=args.exp_name, input_n=args.input_n, output_n=args.output_n, dct_n=args.dct_n,
                       device=args.device, num_works=args.num_works,
-                      test_manner=args.test_manner, debug_step=args.debug_step)
+                      test_manner=args.test_manner, debug_step=args.debug_step,
+                      batch_size=args.batch_size, epochs=args.epochs,
+                      learning_rate=args.learning_rate)
         acts = define_actions_cmu("all")
 
 else:
     if args.exp_name == "h36m":
         r = H36MRunner(exp_name=args.exp_name, input_n=args.input_n, output_n=args.output_n, dct_n=0,
                        device=args.device, num_works=args.num_works,
-                       test_manner=args.test_manner, debug_step=args.debug_step)
+                       test_manner=args.test_manner, debug_step=args.debug_step,
+                       batch_size=args.batch_size, epochs=args.epochs,
+                       learning_rate=args.learning_rate)
         acts = define_actions("all")
 
     elif args.exp_name == "cmu":
         r = CMURunner(exp_name=args.exp_name, input_n=args.input_n, output_n=args.output_n, dct_n=0,
                       device=args.device, num_works=args.num_works,
-                      test_manner=args.test_manner, debug_step=args.debug_step)
+                      test_manner=args.test_manner, debug_step=args.debug_step,
+                      batch_size=args.batch_size, epochs=args.epochs,
+                      learning_rate=args.learning_rate)
         acts = define_actions_cmu("all")
 
 if args.is_load:

--- a/nets/__init__.py
+++ b/nets/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/layers.py
+++ b/nets/layers.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/msrgcn.py
+++ b/nets/msrgcn.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/msrgcn_short_term.py
+++ b/nets/msrgcn_short_term.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/run/__init__.py
+++ b/run/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 from .h36m_runner import H36MRunner
 from .cmu_runner import CMURunner

--- a/run/cmu_runner.py
+++ b/run/cmu_runner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from datas import CMUMotionDataset, define_actions_cmu, draw_pic_gt_pred
@@ -45,13 +47,18 @@ def lr_decay(optimizer, lr_now, gamma):
     return lr
 
 class CMURunner():
-    def __init__(self, exp_name="cmu", input_n=10, output_n=10, dct_n=15, device="cuda:0", num_works=0, test_manner="all", debug_step=1):
+    def __init__(self, exp_name="cmu", input_n=10, output_n=10, dct_n=15,
+                 device="cuda:0", num_works=0, test_manner="all", debug_step=1,
+                 batch_size=16, epochs=5000, learning_rate=2e-4):
         super(CMURunner, self).__init__()
 
         self.start_epoch = 1
         self.best_accuracy = 1e15
 
-        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n, dct_n=dct_n, device=device, num_works=num_works, test_manner=test_manner)
+        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n,
+                         dct_n=dct_n, device=device, num_works=num_works,
+                         test_manner=test_manner, train_batch_size=batch_size,
+                         lr=learning_rate, n_epoch=epochs)
         print("\n================== Configs =================")
         pprint(vars(self.cfg), indent=4)
         print("==========================================\n")

--- a/run/h36m_runner.py
+++ b/run/h36m_runner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from datas_dct import H36MMotionDataset, define_actions,draw_pic_gt_pred
@@ -46,13 +48,18 @@ def lr_decay(optimizer, lr_now, gamma):
 
 
 class H36MRunner():
-    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15, device="cuda:0", num_works=0, test_manner="all", debug_step=1):
+    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15,
+                 device="cuda:0", num_works=0, test_manner="all", debug_step=1,
+                 batch_size=16, epochs=5000, learning_rate=2e-4):
         super(H36MRunner, self).__init__()
 
         self.start_epoch = 1
         self.best_accuracy = 1e15
 
-        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n, dct_n=dct_n, device=device, num_works=num_works, test_manner=test_manner)
+        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n,
+                         dct_n=dct_n, device=device, num_works=num_works,
+                         test_manner=test_manner, train_batch_size=batch_size,
+                         lr=learning_rate, n_epoch=epochs)
         print("\n================== Configs =================")
         pprint(vars(self.cfg), indent=4)
         print("==========================================\n")

--- a/run_dct/__init__.py
+++ b/run_dct/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from .h36m_runner import H36MRunner

--- a/run_dct/cmu_runner.py
+++ b/run_dct/cmu_runner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from datas_dct import CMUMotionDataset, get_dct_matrix, reverse_dct_torch, define_actions_cmu, draw_pic_gt_pred
@@ -45,13 +47,18 @@ def lr_decay(optimizer, lr_now, gamma):
     return lr
 
 class CMURunner():
-    def __init__(self, exp_name="cmu", input_n=10, output_n=10, dct_n=15, device="cuda:0", num_works=0, test_manner="all", debug_step=1):
+    def __init__(self, exp_name="cmu", input_n=10, output_n=10, dct_n=15,
+                 device="cuda:0", num_works=0, test_manner="all", debug_step=1,
+                 batch_size=16, epochs=5000, learning_rate=2e-4):
         super(CMURunner, self).__init__()
 
         self.start_epoch = 1
         self.best_accuracy = 1e15
 
-        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n, dct_n=dct_n, device=device, num_works=num_works, test_manner=test_manner)
+        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n,
+                         dct_n=dct_n, device=device, num_works=num_works,
+                         test_manner=test_manner, train_batch_size=batch_size,
+                         lr=learning_rate, n_epoch=epochs)
         print("\n================== Configs =================")
         pprint(vars(self.cfg), indent=4)
         print("==========================================\n")

--- a/run_dct/h36m_runner.py
+++ b/run_dct/h36m_runner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 from datas_dct import H36MMotionDataset, get_dct_matrix, reverse_dct_torch, define_actions,draw_pic_gt_pred
@@ -46,13 +48,18 @@ def lr_decay(optimizer, lr_now, gamma):
 
 
 class H36MRunner():
-    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15, device="cuda:0", num_works=0, test_manner="all", debug_step=1):
+    def __init__(self, exp_name="h36m", input_n=10, output_n=10, dct_n=15,
+                 device="cuda:0", num_works=0, test_manner="all", debug_step=1,
+                 batch_size=16, epochs=5000, learning_rate=2e-4):
         super(H36MRunner, self).__init__()
 
         self.start_epoch = 1
         self.best_accuracy = 1e15
 
-        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n, dct_n=dct_n, device=device, num_works=num_works, test_manner=test_manner)
+        self.cfg = Config(exp_name=exp_name, input_n=input_n, output_n=output_n,
+                         dct_n=dct_n, device=device, num_works=num_works,
+                         test_manner=test_manner, train_batch_size=batch_size,
+                         lr=learning_rate, n_epoch=epochs)
         print("\n================== Configs =================")
         pprint(vars(self.cfg), indent=4)
         print("==========================================\n")

--- a/short_term_main.py
+++ b/short_term_main.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 # encoding: utf-8
 
 import numpy as np
@@ -7,6 +9,8 @@ import torch
 import os
 
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 def seed_torch(seed=3450):
     # random.seed(seed)
@@ -65,6 +69,8 @@ elif args.exp_name == "cmu":
                    device=args.device, num_works=args.num_works,
                    test_manner=args.test_manner, debug_step=args.debug_step)
     acts = define_actions_cmu("all")
+
+r.model.to(device)
 
 if args.is_load:
     r.restore(args.model_path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 import subprocess
 import sys
 


### PR DESCRIPTION
## Summary
- add basic logging configuration to all python modules
- implement a simple `DataLoader` class with logging
- extend `Config` and runner classes with batch size, epochs and learning rate
- expose new CLI arguments in `main.py`
- add device fallback in `short_term_main.py`

## Testing
- `pytest -q`
