### PR TITLE
Install CUDA torch in CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -11,6 +11,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.8'
+    - name: Install torch manually with CUDA
+      run: |
+        pip install torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install dependencies
       run: |
         pip install -r assets/requirement.txt

--- a/assets/requirement.txt
+++ b/assets/requirement.txt
@@ -8,6 +8,5 @@ Pillow==8.0.1
 progress==1.5
 PyYAML==5.4.1
 tensorboardX==2.1
-torch==1.7.0+cu110
 torchaudio==0.7.0
 torchvision==0.8.1+cu110


### PR DESCRIPTION
## Summary
- manually install PyTorch in workflow using CUDA build
- clean up requirements to avoid installing Torch twice

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_685dc8d31240832190f29121b02e4d95