### PR TITLE
Centralize logging setup

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -1,5 +1,5 @@
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 import os
 import getpass
 import torch

--- a/datas/__init__.py
+++ b/datas/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/cmu/__init__.py
+++ b/datas/cmu/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/cmu/motiondataset.py
+++ b/datas/cmu/motiondataset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas/data_utils.py
+++ b/datas/data_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/draw_pictures.py
+++ b/datas/draw_pictures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/forward_kinematics.py
+++ b/datas/forward_kinematics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/h36m/__init__.py
+++ b/datas/h36m/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/h36m/motiondataset.py
+++ b/datas/h36m/motiondataset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas/multi_scale.py
+++ b/datas/multi_scale.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas/your_data_loader.py
+++ b/datas/your_data_loader.py
@@ -1,5 +1,6 @@
 import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 
 import numpy as np
 

--- a/datas_dct/__init__.py
+++ b/datas_dct/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/cmu/__init__.py
+++ b/datas_dct/cmu/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/cmu/motiondataset.py
+++ b/datas_dct/cmu/motiondataset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas_dct/data_utils.py
+++ b/datas_dct/data_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/dct.py
+++ b/datas_dct/dct.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 import torch

--- a/datas_dct/draw_pictures.py
+++ b/datas_dct/draw_pictures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/forward_kinematics.py
+++ b/datas_dct/forward_kinematics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/h36m/__init__.py
+++ b/datas_dct/h36m/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/datas_dct/h36m/motiondataset.py
+++ b/datas_dct/h36m/motiondataset.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from torch.utils.data import Dataset

--- a/datas_dct/multi_scale.py
+++ b/datas_dct/multi_scale.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 import torch
 import os
 

--- a/nets/__init__.py
+++ b/nets/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/layers.py
+++ b/nets/layers.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/msrgcn.py
+++ b/nets/msrgcn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/nets/msrgcn_short_term.py
+++ b/nets/msrgcn_short_term.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 '''
 @project : MSRGCN

--- a/run/__init__.py
+++ b/run/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 from .h36m_runner import H36MRunner
 from .cmu_runner import CMURunner

--- a/run/cmu_runner.py
+++ b/run/cmu_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from datas import CMUMotionDataset, define_actions_cmu, draw_pic_gt_pred

--- a/run/h36m_runner.py
+++ b/run/h36m_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from datas_dct import H36MMotionDataset, define_actions,draw_pic_gt_pred

--- a/run_dct/__init__.py
+++ b/run_dct/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from .h36m_runner import H36MRunner

--- a/run_dct/cmu_runner.py
+++ b/run_dct/cmu_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from datas_dct import CMUMotionDataset, get_dct_matrix, reverse_dct_torch, define_actions_cmu, draw_pic_gt_pred

--- a/run_dct/h36m_runner.py
+++ b/run_dct/h36m_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 from datas_dct import H36MMotionDataset, get_dct_matrix, reverse_dct_torch, define_actions,draw_pic_gt_pred

--- a/short_term_main.py
+++ b/short_term_main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 # encoding: utf-8
 
 import numpy as np

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
-import logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+from utils.logging import setup_logging
+setup_logging()
 import subprocess
 import sys
 

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -1,0 +1,16 @@
+import logging
+
+
+def setup_logging(level=logging.INFO,
+                  fmt="%(asctime)s [%(levelname)s] %(message)s"):
+    """Configure logging for the project.
+
+    Parameters
+    ----------
+    level : int, optional
+        Logging level, by default ``logging.INFO``.
+    fmt : str, optional
+        Log message format, by default ``"%(asctime)s [%(levelname)s] %(message)s"``.
+    """
+    logging.basicConfig(level=level, format=fmt)
+


### PR DESCRIPTION
## Summary
- add `setup_logging` utility
- use `setup_logging()` across modules instead of calling `logging.basicConfig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd3ccb46c8321957c19aac3f901f8