### PR TITLE
Fix CI workflow to use unified deps

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
 
     steps:
 
@@ -21,15 +21,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.8'
-    - name: Install torch manually with CUDA
-      run: |
-        pip install torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install dependencies
       run: |
-        pip install -r assets/requirement.txt
+        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
-        pip install flake8
         flake8 . --exclude=__pycache__,.git,assets
     - name: Run tests
       run: |


### PR DESCRIPTION
## Summary
- use Python 3.8 matrix like the setup step
- install dependencies from `requirements.txt`
- drop manual CUDA wheel install
- run flake8 from installed deps

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy==1.19.4)*

------
https://chatgpt.com/codex/tasks/task_e_685dfb9c4e248321aba2219cf7f7e334